### PR TITLE
Fix to Heroku deploy

### DIFF
--- a/Friends/settings.py
+++ b/Friends/settings.py
@@ -25,9 +25,9 @@ SECRET_KEY = 'django-insecure-_q#49780wg*+0l#8q@d)6lk=@f9&%efgbkrp4(jvb1whl451$f
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False
 
-ALLOWED_HOSTS = ['know-my-friends.herokuapp.com']
+ALLOWED_HOSTS = ['*']
 
-
+STATIC_ROOT = BASE / 'staticfiles'
 # Application definition
 
 INSTALLED_APPS = [

--- a/Friends/settings.py
+++ b/Friends/settings.py
@@ -27,7 +27,7 @@ DEBUG = False
 
 ALLOWED_HOSTS = ['*']
 
-STATIC_ROOT = BASE / 'staticfiles'
+STATIC_ROOT = BASE_DIR / 'staticfiles'
 # Application definition
 
 INSTALLED_APPS = [

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn Friends.wsgi --log-file -

--- a/procfile
+++ b/procfile
@@ -1,1 +1,0 @@
-web: gunicorn Friends.wsgi --log-file -


### PR DESCRIPTION
Hello, firstly I really dont well understand and aspects of django, from what I could gather from the holy internet I concluded your app needs just a few tweaks and would work as a charm ✨

## Problems 
### 1. Undefined `STATIC_DIR`
django apps has statics files like Templates, Heroku for optimisation collects these static files and stores it in a special directory `STATIC_DIR` which too is defined by django only.
Now your app does have these static files but don't have that `STATIC_DIR` variable set, thats what the problem is.

```
         File "/app/.heroku/python/lib/python3.10/site-packages/django/contrib/staticfiles/storage.py", line 39, in path
           raise ImproperlyConfigured(
       django.core.exceptions.ImproperlyConfigured: You're using the staticfiles app without having set the STATIC_ROOT setting to a filesystem path.
 !     Error while running '$ python manage.py collectstatic --noinput'.
       See traceback above for details.
       You may need to update application code to resolve this error.
       Or, you can disable collectstatic for this application:
          $ heroku config:set DISABLE_COLLECTSTATIC=1
       https://devcenter.heroku.com/articles/django-assets
 !     Push rejected, failed to compile Python app.
 !     Push failed
```
#### Solution
From what I could gather is that there are two possible solutions, according to heroku you can enable the `DISABLE_COLLECTSTATIC` flag in heroku so Heroku no longer collects the static files
```
heroku config:set DISABLE_COLLECTSTATIC=1
```
But thats not the best way, what you can do is manually define the `STATIC_DIR` in your `Friends/settings.py`

### 2. Wrong name of Procfile 
The process which are to be run at startup are stored in  `Procfile`,  you have names it `procfile` that's why Heroku can't understand what do to after build leading to the Application Error.
 #### Solution 
Just renamed `procfile` to `Procfile`

I hope this will help
Thank you 🌻